### PR TITLE
fix broken cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Effective Kafka
 ===
 This is the repository accompanying [Effective Kafka](https://apachekafkabook.com).
 
-<a href="https://apachekafkabook.com"><img src="https://www.apachekafkabook.com/hero2x.png" width="50%" alt="Effective Kafka cover"/></a>
+<a href="https://apachekafkabook.com"><img src="https://www.apachekafkabook.com/hero2x.jpeg" width="50%" alt="Effective Kafka cover"/></a>


### PR DESCRIPTION
`png` version of the cover is not accessible, but `jpeg` is.

<img width="482" alt="Screenshot 2021-07-17 at 20 00 34" src="https://user-images.githubusercontent.com/16745500/126044423-424467bc-ac32-43f5-8503-adf7da78b83c.png">
